### PR TITLE
Updated the use of sprite Z-position to reflect grid coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,20 +96,20 @@ Interface functions required to determine sprite images and positions to render 
 
 `PosZ() float64`
 - Needs to return the Z-position of the sprite.
-- A value of `0.5` represents positioning the center of the sprite at the center of the first elevation level.
+- A value of `0.0` represents the very bottom of the floor on the first elevation level.
+- The `VerticalAnchor()` value will be used to determine rendered sprite orientation about the Z-position.
+
+`VerticalAnchor() raycaster.SpriteAnchor`
+- Needs to return the vertical anchor for positioning a sprite image.
+- `raycaster.AnchorBottom`: makes an image shift to the bottom of its Z-position.
+- `raycaster.AnchorCenter`: keeps an image centered to its Z-position.
+- `raycaster.AnchorTop`: makes an image shift to the top of its Z-position.
 
 `Scale() float64`
 - Needs to return the scale factor of the sprite.
 - A value of `1.0` indicates no scaling.
 - Note that scaling below or above `1.0 ` will likely require `VerticalAnchor()` to return desired position
   since the centered scaling point is at the vertical center of the screen.
-
-`VerticalAnchor() raycaster.SpriteAnchor`
-- Needs to return the vertical anchor for positioning a scaled sprite image.
-- It is only used when `Scale()` returns a value other than `1.0`. If not scaling images just make it return any one.
-- `raycaster.AnchorBottom`: makes a scaled image shift to the bottom of the level.
-- `raycaster.AnchorCenter`: keeps a scaled image centered to the level.
-- `raycaster.AnchorTop`: makes a scaled image shift to the top of the level.
 
 `Texture() *ebiten.Image`
 - Needs to return the current image to render.

--- a/camera.go
+++ b/camera.go
@@ -570,7 +570,7 @@ func (c *Camera) castSprite(spriteOrdIndex int) {
 
 	spriteScreenX := int(float64(c.w) / 2 * (1 + transformX/transformY))
 
-	//parameters for scaling and moving the sprites
+	//parameters for scaling and translating the sprites
 	spriteScale := sprite.Scale()
 	spriteAnchor := sprite.VerticalAnchor()
 
@@ -578,7 +578,7 @@ func (c *Camera) castSprite(spriteOrdIndex int) {
 	var vDiv float64 = 1 / spriteScale
 	var vOffset float64 = getAnchorVerticalOffset(spriteAnchor, spriteScale, c.h)
 
-	var vMove float64 = -(sprite.PosZ()-0.5)*float64(c.h) + vOffset
+	var vMove float64 = -sprite.PosZ()*float64(c.h) + vOffset
 
 	vMoveScreen := int(vMove/transformY) + c.pitch + int(c.posZ/transformY)
 
@@ -831,8 +831,9 @@ func (c *Camera) GetPosition() *geom.Vector2 {
 }
 
 // Set camera Z-plane position
-func (c *Camera) SetPositionZ(posZ float64) {
-	c.posZ = posZ
+func (c *Camera) SetPositionZ(gridPosZ float64) {
+	// convert grid position to camera position
+	c.posZ = (gridPosZ - 0.5) * float64(c.h)
 }
 
 // Get camera Z-plane position

--- a/sprite.go
+++ b/sprite.go
@@ -33,25 +33,24 @@ type Sprite interface {
 type SpriteAnchor int
 
 const (
+	// AnchorBottom anchors the bottom of the sprite to its Z-position
 	AnchorBottom SpriteAnchor = iota
+	// AnchorCenter anchors the center of the sprite to its Z-position
 	AnchorCenter
+	// AnchorTop anchors the top of the sprite to its Z-position
 	AnchorTop
 )
 
 func getAnchorVerticalOffset(anchor SpriteAnchor, spriteScale float64, cameraHeight int) float64 {
-	if spriteScale == 1.0 {
-		return 0
-	}
+	halfHeight := float64(cameraHeight) / 2
 
 	switch anchor {
 	case AnchorBottom:
-		halfHeight := float64(cameraHeight) / 2
 		return halfHeight - (spriteScale * halfHeight)
 	case AnchorCenter:
-		return 0
+		return halfHeight
 	case AnchorTop:
-		halfHeight := float64(cameraHeight) / 2
-		return -(spriteScale * halfHeight)
+		return halfHeight + (spriteScale * halfHeight)
 	}
 
 	return 0


### PR DESCRIPTION
- Previously, PosZ of 0.5 indicated a sprite that was on the bottom of the first floor,
  because that was how the camera rendered it.
- Now, PosZ0.0 indicates the bottom of the bottom of the first floor,
  because that is how a collision model would prefer it.